### PR TITLE
Support for Laravel 9 and generating file without ext

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ StubGenerator::from('some/path/to/stub/file.stub') // the stub file path
     ->to('some/path/to/store/generated/file') // the store directory path
     ->as('TheGeneratingFileNameItself') // the generatable file name without extension 
     ->ext('php') // the file extension(optional, by default to php)
+    // ->noExt() // to remove the extension from the file name for the generated file like .env
     ->withReplacers([]) // the stub replacing params
     ->save(); // save the file
 ```

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=7.2.0",
-        "illuminate/support": "^8.57"
+        "illuminate/support": "^8.57||^9.0"
     },
     "autoload" : {
         "psr-4" : {

--- a/src/Concerns/FileHelpers.php
+++ b/src/Concerns/FileHelpers.php
@@ -80,14 +80,15 @@ trait FileHelpers {
      * Get the destination class path.
      *
      * @param  string  $name
-     * @param  string  $name
-     * @param  string  $extension
-     * 
+     * @param  string|null  $extension
+     *
      * @return string
      */
-    protected function getPath(string $path, string $name, string $extension = 'php') {
+    protected function getPath(string $path, string $name, ?string $extension = 'php') {
 
-        return $this->sanitizePath($this->getStoreDirectoryPath($path) . '/') . $name . '.' . $extension;
+        $extension = $extension ? ".$extension" : '';
+
+        return $this->sanitizePath($this->getStoreDirectoryPath($path) . '/') . $name . $extension;
     }
 
 

--- a/src/StubGenerator.php
+++ b/src/StubGenerator.php
@@ -156,6 +156,18 @@ class StubGenerator {
         return $this;
     }
 
+    /**
+     * Determine if the generated file has no extension
+     *
+     * @return self
+     */
+    public function noExt() {
+
+        $this->generatingFileExtension = null;
+
+        return $this;
+    }
+
 
     /**
      * The replaceable key list in the stub file for generating file


### PR DESCRIPTION
In this PR:

* Add support for laravel 9 by bumping the `illuminate/support` version
* Add a new feature to generate files without an extension like `.env` files.

Tests were added accordingly. 